### PR TITLE
Use defer for unlock

### DIFF
--- a/event_bus.go
+++ b/event_bus.go
@@ -26,36 +26,34 @@ func New() *EventBus {
 // Subscribe - subscribe to a channel.
 func (bus *EventBus) Subscribe(channel string, fn interface{}) {
 	bus.lock.Lock()
+	defer bus.lock.Unlock()
 	if !(reflect.TypeOf(fn).Kind() == reflect.Func) {
-		bus.lock.Unlock()
 		return
 	}
 	v := reflect.ValueOf(fn)
 	bus.handlers[channel] = v
 	bus.flagOnce[channel] = false
-	bus.lock.Unlock()
 }
 
 // SubscribeOnce - subscribe to a channel once. Handler will be removed after executing.
 func (bus *EventBus) SubscribeOnce(channel string, fn interface{}) {
 	bus.lock.Lock()
+	defer bus.lock.Unlock()
 	if !(reflect.TypeOf(fn).Kind() == reflect.Func) {
-		bus.lock.Unlock()
 		return
 	}
 	v := reflect.ValueOf(fn)
 	bus.handlers[channel] = v
 	bus.flagOnce[channel] = true
-	bus.lock.Unlock()
 }
 
 // Unsubscribe - remove callback defined for a channel.
 func (bus *EventBus) Unsubscribe(channel string) {
 	bus.lock.Lock()
+	defer bus.lock.Unlock()
 	if _, ok := bus.handlers[channel]; ok {
 		delete(bus.handlers, channel)
 	}
-	bus.lock.Unlock()
 }
 
 func (bus *EventBus) PublishAsync(channel string, args ...interface{}) {
@@ -69,6 +67,7 @@ func (bus *EventBus) PublishAsync(channel string, args ...interface{}) {
 // Publish - execute callback defined for a channel. Any addional argument will be tranfered to the callback.
 func (bus *EventBus) Publish(channel string, args ...interface{}) {
 	bus.lock.Lock()
+	defer bus.lock.Unlock()
 	if handler, ok := bus.handlers[channel]; ok {
 		removeAfterExec, _ := bus.flagOnce[channel]
 		args_ := make([]reflect.Value, 0)
@@ -81,7 +80,6 @@ func (bus *EventBus) Publish(channel string, args ...interface{}) {
 			bus.flagOnce[channel] = false
 		}
 	}
-	bus.lock.Unlock()
 }
 
 func (bus *EventBus) WaitAsync() {


### PR DESCRIPTION
This commit introduces the common idiom of using defer
for releasing locks. This will make the code slightly more
readable and less error prone.
