### PR TITLE
Fix alter handlers slice during iteration

### DIFF
--- a/event_bus_test.go
+++ b/event_bus_test.go
@@ -44,6 +44,21 @@ func TestSubscribeOnce(t *testing.T) {
 	}
 }
 
+func TestSubscribeOnceAndManySubscribe(t *testing.T) {
+	bus := New()
+	event := "topic"
+	flag := 0
+	fn := func() { flag += 1 }
+	bus.SubscribeOnce(event, fn)
+	bus.Subscribe(event, fn)
+	bus.Subscribe(event, fn)
+	bus.Publish(event)
+
+	if flag != 3 {
+		t.Fail()
+	}
+}
+
 func TestUnsubscribe(t *testing.T) {
 	bus := New()
 	handler := func() {}


### PR DESCRIPTION
Handlers slice may be changed by removeHandler and Unsubscribe during iteration, so make a copy and iterate the copied slice.