### PR TITLE
use copy() instead of append() in publish()

### DIFF
--- a/event_bus.go
+++ b/event_bus.go
@@ -134,8 +134,8 @@ func (bus *EventBus) Publish(topic string, args ...interface{}) {
 	if handlers, ok := bus.handlers[topic]; ok && 0 < len(handlers) {
 		// Handlers slice may be changed by removeHandler and Unsubscribe during iteration,
 		// so make a copy and iterate the copied slice.
-		copyHandlers := make([]*eventHandler, 0, len(handlers))
-		copyHandlers = append(copyHandlers, handlers...)
+		copyHandlers := make([]*eventHandler, len(handlers))
+		copy(copyHandlers, handlers)
 		for i, handler := range copyHandlers {
 			if handler.flagOnce {
 				bus.removeHandler(topic, i)


### PR DESCRIPTION
Thanks for some very useful code.

In Publish(), it does an `append` in order to prevent issues with removal. 

I found a test suite that shows that `copy` is faster. The similar code would be BenchmarkAppendAlloc (645ns/op) vs. BenchmarkCopy (521ns/op).

https://gist.github.com/xogeny/b819af6a0cf8ba1caaef

```
go test -bench=.
goos: darwin
goarch: amd64
BenchmarkAppend-12               	 1000000	      1087 ns/op
BenchmarkAppendAlloc-12          	 3000000	       645 ns/op
BenchmarkAppendAllocInline-12    	 3000000	       508 ns/op
BenchmarkCopy-12                 	 5000000	       521 ns/op
PASS
ok  	_/tmp/append_vs_copy	8.642s
```