### PR TITLE
Handler locking should not affect eventbus lock

### DIFF
--- a/event_bus.go
+++ b/event_bus.go
@@ -145,7 +145,9 @@ func (bus *EventBus) Publish(topic string, args ...interface{}) {
 			} else {
 				bus.wg.Add(1)
 				if handler.transactional {
+					bus.lock.Unlock()
 					handler.Lock()
+					bus.lock.Lock()
 				}
 				go bus.doPublishAsync(handler, topic, args...)
 			}


### PR DESCRIPTION
A transactional async subscription receives two messages. The first message blocks forever in the handler. The second message blocks forever in handler.Lock(), and never releases eventbus.lock.Unlock(). And so the eventbus deadlocks.