### PR TITLE
Fixed bug with subscribe/unsubscribe flow for type methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1.x
 
 notifications:
   email:

--- a/event_bus.go
+++ b/event_bus.go
@@ -184,7 +184,8 @@ func (bus *EventBus) removeHandler(topic string, idx int) {
 func (bus *EventBus) findHandlerIdx(topic string, callback reflect.Value) int {
 	if _, ok := bus.handlers[topic]; ok {
 		for idx, handler := range bus.handlers[topic] {
-			if handler.callBack == callback {
+			if handler.callBack.Type() == callback.Type() &&
+				handler.callBack.Pointer() == callback.Pointer() {
 				return idx
 			}
 		}

--- a/event_bus_test.go
+++ b/event_bus_test.go
@@ -71,6 +71,34 @@ func TestUnsubscribe(t *testing.T) {
 	}
 }
 
+type handler struct {
+	val int
+}
+
+func (h *handler) Handle() {
+	h.val++
+}
+
+func TestUnsubscribeMethod(t *testing.T) {
+	bus := New()
+	h := &handler{val: 0}
+
+	bus.Subscribe("topic", h.Handle)
+	bus.Publish("topic")
+	if bus.Unsubscribe("topic", h.Handle) != nil {
+		t.Fail()
+	}
+	if bus.Unsubscribe("topic", h.Handle) == nil {
+		t.Fail()
+	}
+	bus.Publish("topic")
+	bus.WaitAsync()
+
+	if h.val != 1 {
+		t.Fail()
+	}
+}
+
 func TestPublish(t *testing.T) {
 	bus := New()
 	bus.Subscribe("topic", func(a int, b int) {


### PR DESCRIPTION
I found an interesting case with subscribe/unsubscribe workflow. This test case demonstrates the issue
```go
type handler struct {
	val int
}

func (h *handler) Handle() {
	h.val++
}

func TestUnsubscribeMethod(t *testing.T) {
	bus := New()
	h := &handler{val: 0}

	bus.Subscribe("topic", h.Handle)
	bus.Publish("topic")
	if bus.Unsubscribe("topic", h.Handle) != nil {
		t.Fail()
	}
	if bus.Unsubscribe("topic", h.Handle) == nil {
		t.Fail()
	}
	bus.Publish("topic")
	bus.WaitAsync()

	if h.val != 1 {
		t.Fail()
	}
}
``` 

It seems that simple comparing doesn't work for `reflect.Value` objects. This PR aims to fix this issue.