### PR TITLE
fix(event_bus): panic if multiple goroutine call publish and then wait

### DIFF
--- a/event_bus.go
+++ b/event_bus.go
@@ -211,5 +211,7 @@ func (bus *EventBus) setUpPublish(callback *eventHandler, args ...interface{}) [
 
 // WaitAsync waits for all async callbacks to complete
 func (bus *EventBus) WaitAsync() {
+	bus.lock.Lock()
+	defer bus.lock.Unlock()
 	bus.wg.Wait()
 }

--- a/event_bus_test.go
+++ b/event_bus_test.go
@@ -188,3 +188,18 @@ func TestSubscribeAsync(t *testing.T) {
 	//	t.Fail()
 	//}
 }
+
+func TestSubscribeAsyncWithMultipleGoroutine(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		bus := New()
+		bus.SubscribeAsync("topic", func() {
+			time.Sleep(time.Millisecond)
+		}, false)
+		bus.Publish("topic")
+		go func() {
+			time.Sleep(time.Millisecond)
+			bus.Publish("topic")
+		}()
+		bus.WaitAsync()
+	}
+}


### PR DESCRIPTION
Because of wg's counter can't be a negative number, if call Wait() and then call Add(1) before Wait() complete, it will throw a panic "WaitGroup is reused before previous Wait has returned". so this PR add a mutex to fix the issue.

For more detail, see:
https://stackoverflow.com/questions/48351816/waitgroup-is-reused-before-previous-wait-unknown-reason

I write a test TestSubscribeAsyncWithMultipleGoroutine that can reproduce the issue.

```go
func TestSubscribeAsyncWithMultipleGoroutine(t *testing.T) {
	for i := 0; i < 100; i++ {
		bus := New()
		bus.SubscribeAsync("topic", func() {
			time.Sleep(time.Millisecond)
		}, false)
		bus.Publish("topic")
		go func() {
			time.Sleep(time.Millisecond)
			bus.Publish("topic")
		}()
		bus.WaitAsync()
	}
}
```