### PR TITLE
Add go.mod file for use with go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/asaskevich/EventBus
+
+go 1.16


### PR DESCRIPTION
For those of us using go modules, it would be nice to support it. Pretty straightforward here since this is only one package.

BTW, the go version number doesn't mean that that version is required. Here's [Ian's explanation](https://github.com/golang/go/issues/30791#issuecomment-472217112) about the version number.

The repo will also need a version tagged so those using modules can point at it.

Thanks Alex!